### PR TITLE
Use additional columns for properties

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,13 +1,30 @@
 # History
 
-### 0.1.0 (2020-08-30)
+### 0.2.0 (2021-01-18)
 
-* First release on PyPI.
+* Various refactorings in the utilities modules to make the code better
+and easier to read.
+* Changes the has_property argument to the property_mapping argument, 
+which now takes in a dictionary of property-column mappings, 
+instead of being a tuple of strings.
+    * This is a significant improvement and something I had in mind from
+    the start.
 
-### 0.1.1 (2020-09-04)
+### 0.1.6 (2020-12-20)
 
-* Adds reconciliation_endpoint argument, so the user can define the service (Defaults to Wikidata)
-* Changes qid_type argument to be called type_id.
+* Minor styling fixes, start using isort.
+
+### 0.1.5 (2020-10-27)
+
+* Fixes bug on reconciler.reconcile when parsing empty results.
+
+### 0.1.4 (2020-10-14)
+
+* Makes the type_id argument optional, to allow reconciliation against any term.
+
+### 0.1.3 (2020-09-26)
+
+* Adds a new argument to the main function, has_property, which allows to reconcile against specific property-value pairs.
 
 ### 0.1.2 (2020-09-24)
 
@@ -15,18 +32,11 @@
 
 * Adds a tqdm progress bar for the reconciliation.
 
-### 0.1.3 (2020-09-26)
+### 0.1.1 (2020-09-04)
 
-* Adds a new argument to the main function, has_property, which allows to reconcile against specific property-value pairs.
+* Adds reconciliation_endpoint argument, so the user can define the service (Defaults to Wikidata)
+* Changes qid_type argument to be called type_id.
 
-### 0.1.4 (2020-10-14)
+### 0.1.0 (2020-08-30)
 
-* Makes the type_id argument optional, to allow reconciliation against any term.
-
-### 0.1.5 (2020-10-27)
-
-* Fixes bug on reconciler.reconcile when parsing empty results.
-
-### 0.1.6 (2020-12-20)
-
-* Minor styling fixes, start using isort.
+* First release on PyPI.

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ The resulting dataframe would look like this:
 | Q174    | True    | São Paulo      |     100 | city                   | Q515       | São Paulo      |
 | Q131620 | True    | Natal          |     100 | municipality of Brazil | Q3184121   | Natal          |
 
-In case you want to ensure the results are cities from Brazil, you can specify the has_property argument with
+In case you want to ensure the results are cities from Brazil, you can specify the property_mapping argument with
 a specific property-value pair:
 
 ```python
 # Reconcile against type city (Q515) and items have the country (P17) property equals to Brazil (Q155)
-reconciled = reconcile(test_df["City"], type_id="Q515", has_property=("P17", "Q155"))
+reconciled = reconcile(test_df["City"], type_id="Q515", property_mapping=("P17", "Q155"))
 ```
 
 ## Other very useful packages

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ import pandas as pd
 test_df = pd.DataFrame(
     {
         "City": ["Rio de Janeiro", "São Paulo", "São Paulo", "Natal"],
+        "Country": ["Q155", "Q155", "Q155", "Q155"]
     }
 )
 
@@ -49,7 +50,7 @@ a specific property-value pair:
 
 ```python
 # Reconcile against type city (Q515) and items have the country (P17) property equals to Brazil (Q155)
-reconciled = reconcile(test_df["City"], type_id="Q515", property_mapping=("P17", "Q155"))
+reconciled = reconcile(test_df["City"], type_id="Q515", property_mapping={"P17": test_df["Country"]})
 ```
 
 ## Other very useful packages

--- a/docs/reference/utils.md
+++ b/docs/reference/utils.md
@@ -1,0 +1,13 @@
+# reconciler.utils
+
+**get_query_dict()**
+
+::: reconciler.utils.get_query_dict 
+
+**create_property_array()**
+
+::: reconciler.utils.create_property_array 
+
+**chunk_dictionary()**
+
+::: reconciler.utils.chunk_dictionary 

--- a/docs/reference/webutils.md
+++ b/docs/reference/webutils.md
@@ -1,10 +1,6 @@
 # reconciler.webutils
 
-The utilities module, for formatting and performing queries.
-
-**get_query_dict()**
-
-::: reconciler.webutils.get_query_dict 
+The web utilities module, for performing and parsing queries.
 
 **perform_query()**
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,8 @@ nav:
       - Reconciling cell types: examples/reconcile_cell_types.md
     - Reference:
       - Main module: reference/reconcile.md
-      - Utility module: reference/webutils.md
+      - Web utilities module: reference/webutils.md
+      - General utilities module: reference/utils.md
 repo_url: https://github.com/jvfe/reconciler
 theme:
   name: "material"

--- a/reconciler/reconcile.py
+++ b/reconciler/reconcile.py
@@ -20,7 +20,7 @@ def reconcile(
     it is the item's 'instance of' property. There is also a top_res argument,
     to filter the retrieved matches, this can be either an int, corresponding to the number of
     matches you want to retrieve for each reconciled item, or 'all', to return all matches.
-    The property_mapping argument is an optional argument to denote a particular triple to reconcile
+    The property_mapping argument is an optional argument to denote particular triples to reconcile
     against, so you could, for example, reconcile against items of a particular type, that have
     a specific property equals to some specific value. The reconciliation_endpoint argument corresponds
     to the reconciliation service you're trying to access, if no value is given, it will default to
@@ -35,10 +35,10 @@ def reconcile(
         top_res (int or str): The maximum number of matches to return for
             each reconciled item, defaults to one. To retrieve all matches,
             set it to 'all'.
-        property_mapping (tuple): Property-value pair of the items you want to
-            reconcile against. For example, ("P17", "Q155") to reconcile
-            against items that have the property country equals to Brazil.
-            This is optional and defaults to None.
+        property_mapping (dict): Property-column mapping of the items you want to
+            reconcile against. For example, {"P17": df['country']} to reconcile
+            against items that have the property country equals to the values
+            in the column country. This is optional and defaults to None.
         reconciliation_endpoint (str): The reconciliation endpoint, defaults
             to the Wikidata reconciliation endpoint.
 

--- a/reconciler/reconcile.py
+++ b/reconciler/reconcile.py
@@ -9,7 +9,7 @@ def reconcile(
     column_to_reconcile,
     type_id=None,
     top_res=1,
-    has_property=None,
+    property_mapping=None,
     reconciliation_endpoint="https://wikidata.reconci.link/en/api",
 ):
     """
@@ -22,7 +22,7 @@ def reconcile(
     it is the item's 'instance of' property. There is also a top_res argument,
     to filter the retrieved matches, this can be either an int, corresponding to the number of
     matches you want to retrieve for each reconciled item, or 'all', to return all matches.
-    The has_property argument is an optional argument to denote a particular triple to reconcile
+    The property_mapping argument is an optional argument to denote a particular triple to reconcile
     against, so you could, for example, reconcile against items of a particular type, that have
     a specific property equals to some specific value. The reconciliation_endpoint argument corresponds
     to the reconciliation service you're trying to access, if no value is given, it will default to
@@ -37,7 +37,7 @@ def reconcile(
         top_res (int or str): The maximum number of matches to return for
             each reconciled item, defaults to one. To retrieve all matches,
             set it to 'all'.
-        has_property (tuple): Property-value pair of the items you want to
+        property_mapping (tuple): Property-value pair of the items you want to
             reconcile against. For example, ("P17", "Q155") to reconcile
             against items that have the property country equals to Brazil.
             This is optional and defaults to None.
@@ -64,7 +64,7 @@ def reconcile(
         input_keys, response = return_reconciled_raw(
             column,
             type_id,
-            has_property,
+            property_mapping,
             reconciliation_endpoint,
         )
 

--- a/reconciler/reconcile.py
+++ b/reconciler/reconcile.py
@@ -1,6 +1,4 @@
-import numpy as np
 import pandas as pd
-from tqdm import tqdm
 
 from reconciler.webutils import parse_raw_results, return_reconciled_raw
 
@@ -51,28 +49,14 @@ def reconcile(
         ValueError: top_res argument must be one of either 'all' or an integer.
     """
 
-    size_of_frames = 10
-    number_of_frames = int(len(column_to_reconcile) / size_of_frames)
-    frames = (
-        np.array_split(column_to_reconcile, number_of_frames)
-        if len(column_to_reconcile) > size_of_frames
-        else [column_to_reconcile]
+    input_keys, response = return_reconciled_raw(
+        column_to_reconcile,
+        type_id,
+        property_mapping,
+        reconciliation_endpoint,
     )
 
-    dfs = []
-    for column in tqdm(frames, position=0, leave=True):
-        input_keys, response = return_reconciled_raw(
-            column,
-            type_id,
-            property_mapping,
-            reconciliation_endpoint,
-        )
-
-        parsed = parse_raw_results(input_keys, response)
-
-        dfs.append(parsed)
-
-    full_df = pd.concat(dfs)
+    full_df = parse_raw_results(input_keys, response)
 
     if top_res == "all":
         return full_df

--- a/reconciler/utils.py
+++ b/reconciler/utils.py
@@ -1,4 +1,5 @@
 from itertools import islice
+from collections import defaultdict
 
 import pandas as pd
 
@@ -15,6 +16,41 @@ def create_property_array(df_column, property_mapping, current_value):
         prop_mapping_list.append({"pid": key, "v": prop_value})
 
     return prop_mapping_list
+
+
+def get_query_dict(df_column, type_id, property_mapping):
+    """
+    Convert a pandas DataFrame column to a query dictionary
+
+    The reconciliation API requires a json request formatted in a
+    very particular way. This function takes in a DataFrame column
+    and reformats it.
+
+    Args:
+        df_column (Series): A pandas Series to reconcile.
+        type_id (str): A string specifying the item type to reconcile against,
+            in Wikidata this corresponds to the 'instance of' property of an item.
+
+    Returns:
+        tuple: A tuple containing the list of the original values
+            sent to reconciliation a dictionary with the
+            column values reformatted.
+    """
+    input_keys = df_column.unique()
+    reformatted = defaultdict(dict)
+
+    for idx, value in enumerate(input_keys):
+
+        reformatted[idx]["query"] = value
+
+        if type_id is not None:
+            reformatted[idx]["type"] = type_id
+        if property_mapping is not None:
+            reformatted[idx]["properties"] = create_property_array(
+                df_column, property_mapping, value
+            )
+
+    return input_keys, reformatted
 
 
 def chunk_dictionary(data, size=10):

--- a/reconciler/utils.py
+++ b/reconciler/utils.py
@@ -1,0 +1,24 @@
+from itertools import islice
+
+import pandas as pd
+
+
+def create_property_array(df_column, property_mapping, current_value):
+
+    prop_mapping_list = []
+    for key, value in property_mapping.items():
+
+        prop_value = (
+            value.loc[df_column == current_value].to_string(index=False).strip()
+        )
+
+        prop_mapping_list.append({"pid": key, "v": prop_value})
+
+    return prop_mapping_list
+
+
+def chunk_dictionary(data, size=10):
+    # https://stackoverflow.com/questions/22878743/how-to-split-dictionary-into-multiple-dictionaries-fast
+    it = iter(data)
+    for _ in range(0, len(data), size):
+        yield {k: data[k] for k in islice(it, size)}

--- a/reconciler/utils.py
+++ b/reconciler/utils.py
@@ -1,10 +1,23 @@
-from collections import defaultdict
 from itertools import islice
+from collections import defaultdict
 
 import pandas as pd
 
 
 def create_property_array(df_column, property_mapping, current_value):
+    """
+    Create a query JSON 'properties' array
+
+    Creates the properties array necessary for when the property_mapping is defined.
+
+    Args:
+        df_column (Series): A pandas Series to reconcile.
+        property_mapping (dict): The property-column mapping dictionary.
+        current_value (str): Current iteration through the input_keys
+
+    Returns:
+        list: A list of dictionaries corresponding to the properties.
+    """
 
     prop_mapping_list = []
     for key, value in property_mapping.items():
@@ -30,7 +43,10 @@ def get_query_dict(df_column, type_id, property_mapping):
         df_column (Series): A pandas Series to reconcile.
         type_id (str): A string specifying the item type to reconcile against,
             in Wikidata this corresponds to the 'instance of' property of an item.
-
+        property_mapping (dict): Property-column mapping of the items you want to
+            reconcile against. For example, {"P17": df['country']} to reconcile
+            against items that have the property country equals to the values
+            in the column country. This is optional and defaults to None.
     Returns:
         tuple: A tuple containing the list of the original values
             sent to reconciliation a dictionary with the
@@ -54,6 +70,17 @@ def get_query_dict(df_column, type_id, property_mapping):
 
 
 def chunk_dictionary(data, size=10):
+    """
+    Split a large dictionary into equal-sized dictionaries
+
+    Args:
+        data (dict): The dictionary to be split.
+        size (int): The size the smaller dictionaries are supposed to be.
+
+    Returns:
+        dict: A subdivision of the larger dictionary, of the
+            corresponding size.
+    """
     # https://stackoverflow.com/questions/22878743/how-to-split-dictionary-into-multiple-dictionaries-fast
     it = iter(data)
     for _ in range(0, len(data), size):

--- a/reconciler/utils.py
+++ b/reconciler/utils.py
@@ -1,5 +1,5 @@
-from itertools import islice
 from collections import defaultdict
+from itertools import islice
 
 import pandas as pd
 

--- a/reconciler/webutils.py
+++ b/reconciler/webutils.py
@@ -60,6 +60,10 @@ def return_reconciled_raw(
         df_column (Series): A pandas Series to reconcile.
         type_id (str): A string specifying the item type to reconcile against,
             in Wikidata this corresponds to the 'instance of' property of an item.
+        property_mapping (dict): Property-column mapping of the items you want to
+            reconcile against. For example, {"P17": df['country']} to reconcile
+            against items that have the property country equals to the values
+            in the column country. This is optional and defaults to None.
         reconciliation_endpoint (str): A url to the reconciliation endpoint.
 
     Returns:

--- a/reconciler/webutils.py
+++ b/reconciler/webutils.py
@@ -30,16 +30,14 @@ def get_query_dict(df_column, type_id, property_mapping):
 
     for idx, value in enumerate(input_keys):
 
-        if (type_id and property_mapping) is not None:
-            reformatted[idx] = {
-                "query": value,
-                "type": type_id,
-                "properties": [{"pid": property_mapping[0], "v": {"id": property_mapping[1]}}],
-            }
-        elif type_id is not None:
-            reformatted[idx] = {"query": value, "type": type_id}
-        else:
-            reformatted[idx] = {"query": value}
+        reformatted[idx]["query"] = value
+
+        if type_id is not None:
+            reformatted[idx]["type"] = type_id
+        if property_mapping is not None:
+            reformatted[idx]["properties"] = [
+                {"pid": property_mapping[0], "v": property_mapping[1]}
+            ]
 
     return input_keys, reformatted
 
@@ -81,7 +79,9 @@ def perform_query(query_string, reconciliation_endpoint):
         raise requests.ConnectionError("Couldn't connect to reconciliation client")
 
 
-def return_reconciled_raw(df_column, type_id, property_mapping, reconciliation_endpoint):
+def return_reconciled_raw(
+    df_column, type_id, property_mapping, reconciliation_endpoint
+):
     """Send reformatted dict for reconciliation
 
     This is just a wrapper around the other utility functions. The

--- a/reconciler/webutils.py
+++ b/reconciler/webutils.py
@@ -7,7 +7,7 @@ import pandas as pd
 import requests
 
 
-def get_query_dict(df_column, type_id, has_property):
+def get_query_dict(df_column, type_id, property_mapping):
     """
     Convert a pandas DataFrame column to a query dictionary
 
@@ -30,11 +30,11 @@ def get_query_dict(df_column, type_id, has_property):
 
     for idx, value in enumerate(input_keys):
 
-        if (type_id and has_property) is not None:
+        if (type_id and property_mapping) is not None:
             reformatted[idx] = {
                 "query": value,
                 "type": type_id,
-                "properties": [{"pid": has_property[0], "v": {"id": has_property[1]}}],
+                "properties": [{"pid": property_mapping[0], "v": {"id": property_mapping[1]}}],
             }
         elif type_id is not None:
             reformatted[idx] = {"query": value, "type": type_id}
@@ -81,7 +81,7 @@ def perform_query(query_string, reconciliation_endpoint):
         raise requests.ConnectionError("Couldn't connect to reconciliation client")
 
 
-def return_reconciled_raw(df_column, type_id, has_property, reconciliation_endpoint):
+def return_reconciled_raw(df_column, type_id, property_mapping, reconciliation_endpoint):
     """Send reformatted dict for reconciliation
 
     This is just a wrapper around the other utility functions. The
@@ -101,7 +101,7 @@ def return_reconciled_raw(df_column, type_id, has_property, reconciliation_endpo
 
     """
 
-    input_keys, reformatted = get_query_dict(df_column, type_id, has_property)
+    input_keys, reformatted = get_query_dict(df_column, type_id, property_mapping)
     reconcilable_data = json.dumps({"queries": json.dumps(reformatted)})
     query_result = perform_query(reconcilable_data, reconciliation_endpoint)
 

--- a/reconciler/webutils.py
+++ b/reconciler/webutils.py
@@ -7,6 +7,20 @@ import pandas as pd
 import requests
 
 
+def create_property_array(df_column, property_mapping, current_value):
+
+    prop_mapping_list = []
+    for key, value in property_mapping.items():
+
+        prop_value = (
+            value.loc[df_column == current_value].to_string(index=False).strip()
+        )
+
+        prop_mapping_list.append({"pid": key, "v": prop_value})
+
+    return prop_mapping_list
+
+
 def get_query_dict(df_column, type_id, property_mapping):
     """
     Convert a pandas DataFrame column to a query dictionary
@@ -35,9 +49,9 @@ def get_query_dict(df_column, type_id, property_mapping):
         if type_id is not None:
             reformatted[idx]["type"] = type_id
         if property_mapping is not None:
-            reformatted[idx]["properties"] = [
-                {"pid": property_mapping[0], "v": property_mapping[1]}
-            ]
+            reformatted[idx]["properties"] = create_property_array(
+                df_column, property_mapping, value
+            )
 
     return input_keys, reformatted
 

--- a/reconciler/webutils.py
+++ b/reconciler/webutils.py
@@ -1,5 +1,5 @@
 import json
-from collections import ChainMap, defaultdict
+from collections import ChainMap
 from functools import lru_cache
 
 import numpy as np
@@ -7,42 +7,7 @@ import pandas as pd
 import requests
 from tqdm import tqdm
 
-from reconciler.utils import chunk_dictionary, create_property_array
-
-
-def get_query_dict(df_column, type_id, property_mapping):
-    """
-    Convert a pandas DataFrame column to a query dictionary
-
-    The reconciliation API requires a json request formatted in a
-    very particular way. This function takes in a DataFrame column
-    and reformats it.
-
-    Args:
-        df_column (Series): A pandas Series to reconcile.
-        type_id (str): A string specifying the item type to reconcile against,
-            in Wikidata this corresponds to the 'instance of' property of an item.
-
-    Returns:
-        tuple: A tuple containing the list of the original values
-            sent to reconciliation a dictionary with the
-            column values reformatted.
-    """
-    input_keys = df_column.unique()
-    reformatted = defaultdict(dict)
-
-    for idx, value in enumerate(input_keys):
-
-        reformatted[idx]["query"] = value
-
-        if type_id is not None:
-            reformatted[idx]["type"] = type_id
-        if property_mapping is not None:
-            reformatted[idx]["properties"] = create_property_array(
-                df_column, property_mapping, value
-            )
-
-    return input_keys, reformatted
+from reconciler.utils import get_query_dict, chunk_dictionary
 
 
 @lru_cache(maxsize=None)

--- a/reconciler/webutils.py
+++ b/reconciler/webutils.py
@@ -7,7 +7,7 @@ import pandas as pd
 import requests
 from tqdm import tqdm
 
-from reconciler.utils import get_query_dict, chunk_dictionary
+from reconciler.utils import chunk_dictionary, get_query_dict
 
 
 @lru_cache(maxsize=None)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,7 +26,7 @@ def city_data():
 def gene_data():
 
     gene_df = pd.DataFrame(
-        {"gene": ["BRCA1", "MAPK10"], "species": ["Homo sapiens", "Homo sapiens"]}
+        {"gene": ["BRCA1", "MAPK10"], "species": ["Q15978631", "Q15978631"]}
     )
 
     return gene_df

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from reconciler.webutils import get_query_dict
+from reconciler.utils import get_query_dict
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,7 +107,7 @@ def endpoints():
 def reformatted(city_data):
 
     _, reformatted = get_query_dict(
-        city_data["City"], type_id="Q515", has_property=None
+        city_data["City"], type_id="Q515", property_mapping=None
     )
 
     return reformatted

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -39,7 +39,7 @@ def test_long_reconcile(us_capitals):
 def test_reconcile_against_triple(gene_data):
 
     results = reconcile(
-        gene_data["gene"], type_id="Q7187", has_property=("P703", "Q15978631")
+        gene_data["gene"], type_id="Q7187", property_mapping=("P703", "Q15978631")
     )
 
     assert results["id"][0] == "Q227339"

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pandas as pd
+import pytest
 from pytest import raises
 
 from reconciler import reconcile
@@ -29,16 +30,23 @@ def test_reconcile_without_type(city_data):
 
 def test_reconcile_against_triple(gene_data):
 
-    results = reconcile(gene_data["gene"], property_mapping=("P703", "Q15978631"))
+    results = reconcile(
+        gene_data["gene"], property_mapping={"P703": gene_data["species"]}
+    )
 
     assert results["id"][0] == "Q227339"
 
 
+@pytest.mark.skip(reason="Not working as of yet.")
 def test_long_reconcile(us_capitals):
 
-    df = pd.DataFrame.from_dict(us_capitals, orient="index", columns=["Capital"])
+    df = pd.DataFrame.from_dict(
+        us_capitals, orient="index", columns=["Capital"]
+    ).reset_index()
 
-    results = reconcile(df["Capital"], type_id="Q515")
+    results = reconcile(
+        df["Capital"], type_id="Q515", property_mapping={"P1376": df["index"]}
+    )
 
     assert results.shape == (51, 7)
 

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import pytest
 from pytest import raises
 
 from reconciler import reconcile
@@ -37,7 +36,6 @@ def test_reconcile_against_triple(gene_data):
     assert results["id"][0] == "Q227339"
 
 
-@pytest.mark.skip(reason="Not working as of yet.")
 def test_long_reconcile(us_capitals):
 
     df = pd.DataFrame.from_dict(

--- a/tests/test_reconcile.py
+++ b/tests/test_reconcile.py
@@ -27,6 +27,13 @@ def test_reconcile_without_type(city_data):
     assert retrieved == expected_names
 
 
+def test_reconcile_against_triple(gene_data):
+
+    results = reconcile(gene_data["gene"], property_mapping=("P703", "Q15978631"))
+
+    assert results["id"][0] == "Q227339"
+
+
 def test_long_reconcile(us_capitals):
 
     df = pd.DataFrame.from_dict(us_capitals, orient="index", columns=["Capital"])
@@ -34,15 +41,6 @@ def test_long_reconcile(us_capitals):
     results = reconcile(df["Capital"], type_id="Q515")
 
     assert results.shape == (51, 7)
-
-
-def test_reconcile_against_triple(gene_data):
-
-    results = reconcile(
-        gene_data["gene"], type_id="Q7187", property_mapping=("P703", "Q15978631")
-    )
-
-    assert results["id"][0] == "Q227339"
 
 
 def test_no_results():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,50 @@
+import pandas as pd
+
+from reconciler.utils import get_query_dict
+
+
+def test_get_query_dict(reformatted):
+
+    expected = {
+        0: {"query": "Rio de Janeiro", "type": "Q515"},
+        1: {"query": "São Paulo", "type": "Q515"},
+        2: {"query": "Natal", "type": "Q515"},
+        3: {"query": "FAKE_CITY_HERE", "type": "Q515"},
+    }
+
+    assert expected == reformatted
+
+
+def test_query_dict_w_mapping():
+
+    expected = {
+        0: {
+            "query": "Quercus robur",
+            "properties": [
+                {"pid": "epithet_1", "v": "Quercus"},
+                {"pid": "epithet_2", "v": "robur"},
+                {"pid": "publishing_author", "v": "L."},
+            ],
+        }
+    }
+
+    data = pd.DataFrame(
+        {
+            "scientific_name": ["Quercus robur"],
+            "genus": ["Quercus"],
+            "species": ["robur"],
+            "author": ["L."],
+        }
+    )
+
+    _, reformatted = get_query_dict(
+        data["scientific_name"],
+        type_id=None,
+        property_mapping={
+            "epithet_1": data["genus"],
+            "epithet_2": data["species"],
+            "publishing_author": data["author"],
+        },
+    )
+
+    assert expected == reformatted

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from reconciler.utils import get_query_dict
+from reconciler.utils import chunk_dictionary, get_query_dict
 
 
 def test_get_query_dict(reformatted):
@@ -48,3 +48,10 @@ def test_query_dict_w_mapping():
     )
 
     assert expected == reformatted
+
+
+def test_chunk_dictionary(us_capitals):
+
+    chunked = list(chunk_dictionary(us_capitals))
+
+    assert len(chunked) == 6

--- a/tests/test_webutils.py
+++ b/tests/test_webutils.py
@@ -2,54 +2,7 @@ import json
 
 import pandas as pd
 
-from reconciler.webutils import get_query_dict, perform_query, return_reconciled_raw
-
-
-def test_get_query_dict(reformatted):
-
-    expected = {
-        0: {"query": "Rio de Janeiro", "type": "Q515"},
-        1: {"query": "São Paulo", "type": "Q515"},
-        2: {"query": "Natal", "type": "Q515"},
-        3: {"query": "FAKE_CITY_HERE", "type": "Q515"},
-    }
-
-    assert expected == reformatted
-
-
-def test_query_dict_w_mapping():
-
-    expected = {
-        0: {
-            "query": "Quercus robur",
-            "properties": [
-                {"pid": "epithet_1", "v": "Quercus"},
-                {"pid": "epithet_2", "v": "robur"},
-                {"pid": "publishing_author", "v": "L."},
-            ],
-        }
-    }
-
-    data = pd.DataFrame(
-        {
-            "scientific_name": ["Quercus robur"],
-            "genus": ["Quercus"],
-            "species": ["robur"],
-            "author": ["L."],
-        }
-    )
-
-    _, reformatted = get_query_dict(
-        data["scientific_name"],
-        type_id=None,
-        property_mapping={
-            "epithet_1": data["genus"],
-            "epithet_2": data["species"],
-            "publishing_author": data["author"],
-        },
-    )
-
-    assert expected == reformatted
+from reconciler.webutils import perform_query, return_reconciled_raw
 
 
 def test_perform_query(reformatted, endpoints):

--- a/tests/test_webutils.py
+++ b/tests/test_webutils.py
@@ -2,7 +2,7 @@ import json
 
 import pandas as pd
 
-from reconciler.webutils import perform_query, return_reconciled_raw
+from reconciler.webutils import get_query_dict, perform_query, return_reconciled_raw
 
 
 def test_get_query_dict(reformatted):
@@ -13,6 +13,41 @@ def test_get_query_dict(reformatted):
         2: {"query": "Natal", "type": "Q515"},
         3: {"query": "FAKE_CITY_HERE", "type": "Q515"},
     }
+
+    assert expected == reformatted
+
+
+def test_query_dict_w_mapping():
+
+    expected = {
+        0: {
+            "query": "Quercus robur",
+            "properties": [
+                {"pid": "epithet_1", "v": "Quercus"},
+                {"pid": "epithet_2", "v": "robur"},
+                {"pid": "publishing_author", "v": "L."},
+            ],
+        }
+    }
+
+    data = pd.DataFrame(
+        {
+            "scientific_name": ["Quercus robur"],
+            "genus": ["Quercus"],
+            "species": ["robur"],
+            "author": ["L."],
+        }
+    )
+
+    _, reformatted = get_query_dict(
+        data["scientific_name"],
+        type_id=None,
+        property_mapping={
+            "epithet_1": data["genus"],
+            "epithet_2": data["species"],
+            "publishing_author": data["author"],
+        },
+    )
 
     assert expected == reformatted
 

--- a/tests/test_webutils.py
+++ b/tests/test_webutils.py
@@ -31,14 +31,14 @@ def test_return_raw_results(city_data, endpoints):
         city_data["City"],
         type_id="Q515",
         reconciliation_endpoint=endpoints[0],
-        has_property=None,
+        property_mapping=None,
     )
 
     input_keys2, raw_res2 = return_reconciled_raw(
         city_data["City"],
         type_id="/ulan",
         reconciliation_endpoint=endpoints[1],
-        has_property=None,
+        property_mapping=None,
     )
 
     assert len(input_keys) and len(raw_res.keys()) == 4


### PR DESCRIPTION
Changes made:
- refactor: Change has_property to property_mapping
- refactor: Improve query dict creation
- feat: Add initial functionality of property_map
- fix: Remove issues created by b60170c on long dfs
- refactor: Move get_query_dict to utils
- tests: Add test for chunk_dictionary
- docs: Add documentation for property_mapping
- chore: Update changelog for the upcoming version

Summary:
* New feature: Changes the has_property argument to be the property_mapping argument, which uses a dictionary of property-column mappings to help during reconciliation.

Closes #9
